### PR TITLE
ldap: old ldap doesn't work with modern python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-ldap3<=2.0
+# ldap3 is broken on python3.7+ unless it is a recent version
+ldap3==2.8.1
 PyYAML


### PR DESCRIPTION
You will get:
Traceback (most recent call last):
  File "./toolsctl.py", line 21, in <module>
    import ldap3
  File "/home/bstorm/src/toolsctl/venv/lib/python3.7/site-packages/ldap3/__init__.py", line 406, in <module>
    from .core.connection import Connection
  File "/home/bstorm/src/toolsctl/venv/lib/python3.7/site-packages/ldap3/core/connection.py", line 53
    from ..strategy.async import AsyncStrategy
                        ^
SyntaxError: invalid syntax

On anything less than 1.0 like in the requirements.